### PR TITLE
Fix for multiple joins

### DIFF
--- a/lib/helper/basebuilder.js
+++ b/lib/helper/basebuilder.js
@@ -33,11 +33,11 @@ BaseBuilder.prototype.buildJoin = function(joins, Type) {
     if (joins.length > 0) {
         var tmpJoins = [];
         var join = undefined;
-        var tmp = '';
 
         for(var i = 0; i < joins.length; i++) {
             join = joins[i];
 
+			var tmp = '';
             tmp += ' ' + join.type;
 
             if (join.table instanceof Type) {


### PR DESCRIPTION
If you do multiple join() lines the query builder will double the first join in the sql built. Clearing the tmp variable for each join fixes the problem.
