### PR TITLE
Update basebuilder.js

### DIFF
--- a/lib/helper/basebuilder.js
+++ b/lib/helper/basebuilder.js
@@ -33,9 +33,10 @@ BaseBuilder.prototype.buildJoin = function(joins, Type) {
     if (joins.length > 0) {
         var tmpJoins = [];
         var join = undefined;
-        var tmp = '';
+        var tmp;
 
         for(var i = 0; i < joins.length; i++) {
+            tmp = '';
             join = joins[i];
 
             tmp += ' ' + join.type;


### PR DESCRIPTION
Prior to this change if you join to more than 1 table the query fails because the tmp variable is not cleared in the loop.
